### PR TITLE
The repo is public!

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,8 @@
 			"extensions": [
 				"GitHub.copilot",
 				"yzhang.markdown-all-in-one",
-				"DavidAnson.vscode-markdownlint"
+				"DavidAnson.vscode-markdownlint",
+				"redhat.vscode-yaml"
 			]
 		}
 	},

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 
+
 Checks to run manually:
 
 - [ ] bump version in `Cargo.toml`
 - [ ] code coverage
-- [ ] clippy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Shuttle Deploy
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,3 +15,26 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Enforce formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Linting
+        run: cargo clippy -- -D warnings

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Christmas Code Hunt 🎄
+
+My solutions to [`shuttle`'s Christmas Code Hunt](https://www.shuttle.rs/cch)!
+
+What I'm using:
+
+- 🦀 [Rust](https://www.rust-lang.org) for *fun* ✨
+- 🕸️ [Actix Web](https://actix.rs) for the API
+- 🚀 [Shuttle](https://www.shuttle.rs) for infrastructure
+- 🐳 [Dev Container](https://containers.dev) for development
+- 🪄 [GitHub Actions](https://github.com/features/actions) for CI/CD


### PR DESCRIPTION
Due to service disruption the leaderboard is being dropped and we can make this public!

There are a few things mixed in here:

- Adds CI checks back in
  - Public repos get free GitHub Actions minutes 💸
  - Left out code coverage check because it's slow but I'll keep running it locally
- Removes automation of deployment but the action still exists and can be manually triggered
- Adds a README
