### PR TITLE
Day 6!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "cch"
-version = "2023.12.9-1"
+version = "2023.12.9-2"
 dependencies = [
  "actix-web",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cch"
-version = "2023.12.9-1"
+version = "2023.12.9-2"
 authors = ["Francisco Nevitt Gonçalves <github.com/fng97>"]
 edition = "2021"
 

--- a/src/challenges/day6.rs
+++ b/src/challenges/day6.rs
@@ -1,6 +1,14 @@
-use actix_web::post;
+use actix_web::{post, web};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Response {
+    elf: u32,
+}
 
 #[post("/6")]
-async fn count_elf_sub_strings(_body: String) -> String {
-    r#"{"elf":4}"#.to_string()
+async fn count_elf_sub_strings(body: String) -> web::Json<Response> {
+    web::Json(Response {
+        elf: body.matches("elf").count() as u32,
+    })
 }

--- a/src/challenges/day6.rs
+++ b/src/challenges/day6.rs
@@ -1,4 +1,4 @@
-use actix_web::{post, web};
+use actix_web::{post, web, Either};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -6,9 +6,42 @@ struct Response {
     elf: u32,
 }
 
+#[derive(Serialize)]
+struct ResponseWithShelves {
+    elf: u32,
+    #[serde(rename(serialize = "elf on a shelf"))]
+    elf_on_a_shelf: u32,
+    #[serde(rename(serialize = "shelf with no elf on it"))]
+    shelf_with_no_elf_on_it: u32,
+}
+
 #[post("/6")]
-async fn count_elf_sub_strings(body: String) -> web::Json<Response> {
-    web::Json(Response {
-        elf: body.matches("elf").count() as u32,
-    })
+async fn count_elves_and_shelves(
+    body: String,
+) -> Either<web::Json<Response>, web::Json<ResponseWithShelves>> {
+    let elf_count = count_elves(&body);
+
+    if !body.contains("elf on a shelf") {
+        Either::Left(web::Json(Response { elf: elf_count }))
+    } else {
+        let elves_on_shelves_count = count_elves_on_shelves(&body);
+
+        Either::Right(web::Json(ResponseWithShelves {
+            elf: elf_count,
+            elf_on_a_shelf: elves_on_shelves_count,
+            shelf_with_no_elf_on_it: count_shelves(&body) - elves_on_shelves_count,
+        }))
+    }
+}
+
+fn count_elves(text: &str) -> u32 {
+    text.matches("elf").count() as u32
+}
+
+fn count_elves_on_shelves(text: &str) -> u32 {
+    text.matches("elf on a shelf").count() as u32
+}
+
+fn count_shelves(text: &str) -> u32 {
+    text.matches("shelf").count() as u32
 }

--- a/src/challenges/day6.rs
+++ b/src/challenges/day6.rs
@@ -1,0 +1,6 @@
+use actix_web::post;
+
+#[post("/6")]
+async fn count_elf_sub_strings(_body: String) -> String {
+    r#"{"elf":4}"#.to_string()
+}

--- a/src/challenges/mod.rs
+++ b/src/challenges/mod.rs
@@ -1,3 +1,4 @@
 pub mod day1;
 pub mod day4;
+pub mod day6;
 pub mod warmup;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -11,5 +11,5 @@ pub fn config(cfg: &mut ServiceConfig) {
         .service(day1::recallibrate_ids)
         .service(day4::combine_reindeer_strengths)
         .service(day4::summarise_winners)
-        .service(day6::count_elf_sub_strings);
+        .service(day6::count_elves_and_shelves);
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -2,6 +2,7 @@ use actix_web::web::ServiceConfig;
 
 use crate::challenges::day1;
 use crate::challenges::day4;
+use crate::challenges::day6;
 use crate::challenges::warmup;
 
 pub fn config(cfg: &mut ServiceConfig) {
@@ -9,5 +10,6 @@ pub fn config(cfg: &mut ServiceConfig) {
         .service(warmup::fake_error)
         .service(day1::recallibrate_ids)
         .service(day4::combine_reindeer_strengths)
-        .service(day4::summarise_winners);
+        .service(day4::summarise_winners)
+        .service(day6::count_elf_sub_strings);
 }

--- a/tests/api/day6.rs
+++ b/tests/api/day6.rs
@@ -30,3 +30,40 @@ async fn counts_elf_sub_strings() {
 
     assert_eq!(expected_body, actual_body);
 }
+
+// Task 2
+#[tokio::test]
+async fn counts_elves_and_shelves() {
+    // Arrange
+    let app_address = spawn_app();
+    let client = Client::new();
+
+    // Act
+    let response = client
+        .post(format!("{app_address}/6"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(
+            "there is an elf on a shelf on an elf.
+            there is also another shelf in Belfast.",
+        )
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(200, response.status().as_u16());
+
+    let expected_body: Value = from_str(
+        r#"
+        {
+            "elf": 5,
+            "elf on a shelf": 1,
+            "shelf with no elf on it": 1
+        }
+        "#,
+    )
+    .unwrap();
+    let actual_body: Value = from_str(&response.text().await.unwrap()).unwrap();
+
+    assert_eq!(expected_body, actual_body);
+}

--- a/tests/api/day6.rs
+++ b/tests/api/day6.rs
@@ -1,0 +1,32 @@
+use crate::helpers::spawn_app;
+use reqwest::{header, Client};
+use serde_json::{from_str, Value};
+
+// Task 1
+#[tokio::test]
+async fn counts_elf_sub_strings() {
+    // Arrange
+    let app_address = spawn_app();
+    let client = Client::new();
+
+    // Act
+    let response = client
+        .post(format!("{app_address}/6"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(
+            "The mischievous elf peeked out from behind the toy workshop,
+        and another elf joined in the festive dance.
+        Look, there is also an elf on that shelf!",
+        )
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(200, response.status().as_u16());
+
+    let expected_body: Value = from_str(r#"{"elf":4}"#).unwrap();
+    let actual_body: Value = from_str(&response.text().await.unwrap()).unwrap();
+
+    assert_eq!(expected_body, actual_body);
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,4 +1,5 @@
 mod day1;
 mod day4;
+mod day6;
 mod helpers;
 mod warmup;


### PR DESCRIPTION
🎄 Day 6: Elf on a shelf

It's that time of year when the elves hide on shelves to watch over the children of the world, reporting back to Santa on who's been naughty or nice. However, this year's reports have been mixed up with the rest of the letters to Santa, and the word "elf" is hidden throughout a mountain of text.

⭐ Task 1: Never count on an elf

Elves are notorious for their hide-and-seek skills, and now they've hidden themselves in strings of text!

Create an endpoint /6 that takes a POST request with a raw string as input and count how many times the substring "elf" appears.

The output should be a JSON object containing the count of the string "elf".

🔔 Tips

[Rust Primitive Type str](https://doc.rust-lang.org/std/primitive.str.html)
[Rust String struct](https://doc.rust-lang.org/std/string/struct.String.html)

💠 Examples

```plaintext
curl -X POST http://localhost:8000/6 \
  -H 'Content-Type: text/plain' \
  -d 'The mischievous elf peeked out from behind the toy workshop,
      and another elf joined in the festive dance.
      Look, there is also an elf on that shelf!'
```
```json
{"elf":4}
```

🎁 Task 2: Shelf under an elf? (200 bonus points)

Add two fields to the response that counts:

The number of occurrences of the string "elf on a shelf" in a field with the same name.
The number of shelves that don't have an elf on it. That is, the number of strings "shelf" that are not preceded by the string "elf on a ". Put this count in the field "shelf with no elf on it".

💠 Example

```bash
curl -X POST http://localhost:8000/6 \
  -H 'Content-Type: text/plain' \
  -d 'there is an elf on a shelf on an elf.
      there is also another shelf in Belfast.'
```
```json
{"elf":5,"elf on a shelf":1,"shelf with no elf on it":1}
```

Checks to run manually:

- [x] bump version in `Cargo.toml`
- [x] code coverage
